### PR TITLE
extract_to_dirs creates a folder with a correct name by taking archive name stem

### DIFF
--- a/archives_utils.py
+++ b/archives_utils.py
@@ -273,7 +273,7 @@ def get_decompression_command(
     elif search(r"\.rar$", archive_name) is not None:
         bins = ["7z", "unrar", "rar"]
         binary, binary_path = find_binaries(bins)
-        
+
         if binary == 'rar' or binary == 'unrar':
             command = [binary_path, "x", *flags, archive_name]
             if to_dir:

--- a/compress.py
+++ b/compress.py
@@ -31,7 +31,7 @@ class compress(Command):
                 archive_name = flags_last
 
         if not archive_name:
-            archive_name = os.path.basename(self.fm.thisdir.path) + '.zip'
+            archive_name = f'{os.path.basename(self.fm.thisdir.path)}.zip'
 
         # Preparing command for archiver
         archive_name = archive_name.strip("'")
@@ -39,7 +39,7 @@ class compress(Command):
 
         # Making description line
         files_num_str = f'{files_num} objects' if files_num > 1 else '1 object'
-        descr = f"Compressing {files_num_str} -> " + os.path.basename(archive_name)
+        descr = f"Compressing {files_num_str} -> {os.path.basename(archive_name)}"
 
         # Creating archive
         obj = CommandLoader(args=command, descr=descr, read=True)
@@ -55,4 +55,7 @@ class compress(Command):
         """ Complete with current folder name """
 
         extension = ['.7z', '.zip', '.tar.gz', '.tar.bz2', '.tar.xz']
-        return ['compress ' + os.path.basename(self.fm.thisdir.path) + ext for ext in extension]
+        return [
+            f'compress {os.path.basename(self.fm.thisdir.path)}{ext}'
+            for ext in extension
+        ]

--- a/extract.py
+++ b/extract.py
@@ -1,5 +1,5 @@
 import os
-from re import findall
+import pathlib
 from ranger.api.commands import Command
 from ranger.core.loader import CommandLoader
 from .archives_utils import parse_escape_args, get_decompression_command
@@ -26,7 +26,7 @@ class extract(Command):
         self.fm.cut_buffer = False
 
         for file in files:
-            descr = "Extracting: " + os.path.basename(file.path)
+            descr = f"Extracting: {os.path.basename(file.path)}"
             command = get_decompression_command(file.path, [], dirname)
             obj = CommandLoader(args=command, descr=descr, read=True)
             obj.signal_bind('after', refresh)
@@ -54,7 +54,7 @@ class extract_raw(Command):
         self.fm.cut_buffer = False
 
         for file in files:
-            descr = "Extracting: " + os.path.basename(file.path)
+            descr = f"Extracting: {os.path.basename(file.path)}"
             command = get_decompression_command(file.path, flags)
             obj = CommandLoader(args=command, descr=descr, read=True)
             obj.signal_bind('after', refresh)
@@ -80,8 +80,8 @@ class extract_to_dirs(Command):
         self.fm.cut_buffer = False
 
         for file in files:
-            descr = "Extracting: " + os.path.basename(file.path)
-            dirname = findall(r"(.*?)\.", os.path.basename(file.path))[0]
+            descr = f"Extracting: {os.path.basename(file.path)}"
+            dirname = pathlib.Path(file.path).stem
             command = get_decompression_command(file.path, flags, dirname)
             obj = CommandLoader(args=command, descr=descr, read=True)
             obj.signal_bind('after', refresh)


### PR DESCRIPTION
- fixed issue by using pathlib.Path().stem instead of re.findall
- replaced string concatenation with f-strings for more readability