### PR TITLE
extract_to_dirs fails to extract multiple archives due to flags being changed in an extraction loop

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -82,7 +82,7 @@ class extract_to_dirs(Command):
         for file in files:
             descr = f"Extracting: {os.path.basename(file.path)}"
             dirname = pathlib.Path(file.path).stem
-            command = get_decompression_command(file.path, flags, dirname)
+            command = get_decompression_command(file.path, flags.copy(), dirname)
             obj = CommandLoader(args=command, descr=descr, read=True)
             obj.signal_bind('after', refresh)
             self.fm.loader.add(obj)

--- a/extract.py
+++ b/extract.py
@@ -55,7 +55,7 @@ class extract_raw(Command):
 
         for file in files:
             descr = f"Extracting: {os.path.basename(file.path)}"
-            command = get_decompression_command(file.path, flags)
+            command = get_decompression_command(file.path, flags.copy())
             obj = CommandLoader(args=command, descr=descr, read=True)
             obj.signal_bind('after', refresh)
             self.fm.loader.add(obj)


### PR DESCRIPTION
extract_to_dirs can't handle a lot of files (more than one)
the problem was in ``flags`` argument  changes inside ``get_decompression_command``
so on every file except first, ``flags`` increasing on previous ``-oDEST_DIR`` flag, and all directories except first is empty

**before**
![image](https://user-images.githubusercontent.com/35001580/216685928-34f35051-7bcf-4450-bd4c-b35cc252e10f.png)
![image](https://user-images.githubusercontent.com/35001580/216685997-ca975cf7-003e-4ec1-908d-acaef5641144.png)
![image](https://user-images.githubusercontent.com/35001580/216686021-3bbf9e1c-ae37-4467-bfc7-e66430a92ef6.png)

**after**
![image](https://user-images.githubusercontent.com/35001580/216686459-625b4a59-9041-4ba2-8eef-b31f6554a5a4.png)
![image](https://user-images.githubusercontent.com/35001580/216686479-8fa0580c-74cd-4e52-b2a9-3c1e7761b823.png)

